### PR TITLE
Fix regex to handle default extensions with dot in name

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -243,13 +243,15 @@ return {
                             is_level = true
                         end
                     end
-                elseif arg:match("^%w+$") then
+                elseif arg:match("^%w[%w\\.]*$") then
                     -- Handle default extension (e.g., 7z, zip)
                     if archive_commands["%." .. arg .. "$"] then
                         default_extension = arg
                     else
                         notify_error(string.format("Unsupported extension: %s", arg), "warn")
                     end
+                else
+                      notify_error(string.format("Unknown argument: %s", arg), "warn")
                 end
             end
         end


### PR DESCRIPTION
`%w` accepts only letters, while some extensions have dot in name (for example tar.gz). Add `\\.` to handle these extensions. Also do not accept dot as first char, because it will be added automatically.
Add notification about unknown arguments.